### PR TITLE
Add support for monorepos and WorkspaceConfig interface for route path configuration

### DIFF
--- a/src/constant/workspace-config.type.ts
+++ b/src/constant/workspace-config.type.ts
@@ -1,0 +1,3 @@
+export interface WorkspaceConfig {
+    routesPath?: string;
+}

--- a/src/constant/workspace-config.type.ts
+++ b/src/constant/workspace-config.type.ts
@@ -1,3 +1,4 @@
-export interface WorkspaceConfig {
-    routesPath?: string;
+export 
+interface WorkspaceConfig {
+    projectRoot?: string;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,8 @@
 import * as vscode from 'vscode';
 import { RoutesProvider } from './providers/routesProvider';
 import { RouteItem } from './models/routeItem';
+import path from 'path';
+import fs from 'fs';
 
 export function activate(context: vscode.ExtensionContext) {
 	// Initialize the routes provider
@@ -11,6 +13,32 @@ export function activate(context: vscode.ExtensionContext) {
 		treeDataProvider: routesProvider,
 		showCollapseAll: true
 	});
+
+	const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (workspaceFolders) {
+        const workspaceRoot = workspaceFolders[0].uri.fsPath;
+        const routesDir = routesProvider.getRoutesDir();
+        
+        if (!fs.existsSync(routesDir)) {
+            vscode.window.showWarningMessage(
+                'SvelteKit routes directory not found. Create .vscode/svelte-radar.json to configure root of your sveltekit project.',
+                'Create Config'
+            ).then(selection => {
+                if (selection === 'Create Config') {
+                    const configDir = path.join(workspaceRoot, '.vscode');
+                    const configPath = path.join(configDir, 'svelte-radar.json');
+                    
+                    fs.mkdirSync(configDir, { recursive: true });
+                    fs.writeFileSync(configPath, JSON.stringify({
+                        projectRoot: "frontend/"
+                    }, null, 2));
+                    
+                    vscode.workspace.openTextDocument(configPath)
+                        .then(doc => vscode.window.showTextDocument(doc));
+                }
+            });
+        }
+    }
 
 	// Register commands
 	const commands = [


### PR DESCRIPTION
This update introduces a `WorkspaceConfig` interface to allow configuration of the project root for SvelteKit routes. It also enhances the extension to support monorepo structures by checking for a configuration file and adjusting the routes directory accordingly. This resolves the issue of the SvelteKit routes directory not being found in monorepo setups. Fixes #12